### PR TITLE
Make extending from `a` optional.

### DIFF
--- a/assets/lib/_links.scss
+++ b/assets/lib/_links.scss
@@ -32,7 +32,7 @@
 
 %button-as-link,
 .button-link {
-  @extend a;
+  @extend a !optional;
   background: transparent;
   border: none;
 }


### PR DESCRIPTION
It's not currently used, but could be in future?

Happy to just remove it.

Relates to https://github.com/moneyadviceservice/frontend/pull/891.