### PR TITLE
Adding 'all' SCSS file to import all partials

### DIFF
--- a/assets/_all.scss
+++ b/assets/_all.scss
@@ -1,0 +1,11 @@
+@import 'lib/all';
+
+@import 'helpers/*';
+
+@import 'base/*';
+
+@import 'layout/variables';
+@import 'layout/common/all';
+
+@import 'components/dough_theme/variables';
+@import 'components/dough_theme/all';


### PR DESCRIPTION
@JiggyPete @KateWilkinson this should be a tidier way of getting the Yeast styles into other projects such as UC.

If you just add this line to your project stylesheet this will get all of the Yeast partials.

`@import 'yeast/assets/all';`