### PR TITLE
[DEV APPROVED] - TP: 7559, Comment: adds focus styles to the clear button on search bar

### DIFF
--- a/assets/base/_forms.scss
+++ b/assets/base/_forms.scss
@@ -48,10 +48,6 @@ select {
   }
 }
 
-button.search__clear:focus {
-  outline: none;
-}
-
 textarea {
   @extend %form-input;
 }


### PR DESCRIPTION
Removes an earlier addition that excludes the clear button in the search bar from displaying a focus style.

Current: 
![image](https://cloud.githubusercontent.com/assets/6080548/17893430/941d2374-693d-11e6-9293-42bebad46bcc.png)

Updated: 
![image](https://cloud.githubusercontent.com/assets/6080548/17893424/8bd333c0-693d-11e6-8c51-c4bec19080e3.png)
