### PR TITLE
[WIP] 7730 - Adjustment to the footer for fincap link

### DIFF
--- a/assets/layout/common/_footer.scss
+++ b/assets/layout/common/_footer.scss
@@ -204,12 +204,6 @@
       text-transform: uppercase;
       text-decoration: none;
       @include body(18, 18);
-
-      @include respond-to($mq-xl) {
-        position: absolute;
-        top: 50%;
-        margin-top: -21px;
-      }
     }
 
     .footer-primary__blog-link:hover {


### PR DESCRIPTION
## 7730 - Adjustment to the footer for fincap link

There is some CSS applied to the blog button in the footer which I believe does not need to be there and causes display issues when a new link is added beneath it.  This is applied specifically to the blog link in the footer.

```
@include respond-to($mq-xl) {
   position: absolute;
   top: 50%;
   margin-top: -21px;
 }
```

This sets the position to absolute, moves the element down, then up again with a negative margin.  Please see the related frontend PR: https://github.com/moneyadviceservice/frontend/pull/1587 where tests have been carried out across browsers and screen sizes with this removed locally.