### PR TITLE
Bumping Yeast version to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,12 @@
 {
   "name": "yeast",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
-    "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>"
+    "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",
+    "Matt Saywell <matt.saywell@moneyadviceservice.org.uk>",
+    "David Trussler <david.trussler@moneyadviceservice.org.uk>",
+    "John Player <john.player@moneyadviceservice.org.uk>"
   ],
   "description": "Shared SASS mixins, variables and functions for MAS",
   "license": "MIT",


### PR DESCRIPTION
We are trying to use the Bower registry for Yeast so that we can start semantically versioning it - this  PR bumps it to 1.0.0.

Yeast will not appear in the Bower registry as we have set `"private": true,` in the bower.json, and since this is already a public repo that contains only (S)CSS there is no risk putting this in the Bower component registry.