### PR TITLE
7757 - New styles for Callout module

### DIFF
--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -49,6 +49,18 @@
   }
 }
 
+.callout--tool {
+  border: 2px solid $color-callout-tool;
+  h3 {
+    background: $color-callout-tool;
+    &:before {
+      @extend %callout-icon;
+      content: '';
+      vertical-align: middle;
+    }
+  }
+}
+
 .callout--instructional {
   background-color: $color-panel-background;
 }

--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -4,58 +4,42 @@
 //
 // Styleguide Call out
 
-$callout-border-top-height: 45px;
-
-%callout-icon {
-  @include body(22, 30);
-  border-radius: 50%;
-  display: inline-block;
-  vertical-align: middle;
-  height: 30px;
-  width: 30px;
-  background: white;
-  margin-right: $baseline-unit;
-  font-weight: 700;
-  text-align: center;
-}
+$callout-border-top-height: 42px;
 
 .callout {
   position: relative;
   margin: $baseline-unit*2 0;
   border: 2px solid $color-callout-general;
-  border-top: $callout-border-top-height solid $color-callout-general;
   clear: right;
 
   h3 {
     @extend %heading-small;
+    text-indent: $baseline-unit*6;
     color: white;
     background: $color-callout-general;
     margin: 0;
-    margin-top: -$callout-border-top-height;
-    padding: $baseline-unit $baseline-unit $baseline-unit $baseline-unit*3;
-
-    &:before {
-      @extend %callout-icon;
-      content: '?';
-      color: $color-callout-general;
-    }
+    padding: $baseline-unit;
   }
 
-  p:first-child:before {
-    @extend %callout-icon;
-    content: '?';
-    color: $color-callout-general;
-    position: absolute;
-    top: -$callout-border-top-height + 7px;
+  span.callout__icon + p {
+    margin-top: $callout-border-top-height + 12px;
+    &:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: $callout-border-top-height;
+      background: $color-callout-general;
+    }
   }
 
   p {
     @extend %type-callout;
-    margin: $baseline-unit*3;
+    margin: $baseline-unit*2;
   }
 
   .editorial & {
-
     @include respond-to($mq-l) {
       @include column(3.5, 7);
       float: right;
@@ -66,18 +50,35 @@ $callout-border-top-height: 45px;
 
 .callout--tool {
   border: 2px solid $color-callout-tool;
-  border-top: $callout-border-top-height solid $color-callout-tool;
   h3 {
     background: $color-callout-tool;
-    &:before {
-      @extend %callout-icon;
-      content: '';
-      vertical-align: middle;
-    }
   }
-  p:first-child:before {
-    content: " ";
+  span.callout__icon + p:before {
+    background: $color-callout-tool;
   }
+}
+
+.callout__icon {
+  @include body(22, 30);
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  height: 32px;
+  width: 32px;
+  z-index: 1;
+  background: white;
+  border-radius: 50%;
+  text-align: center;
+  font-weight: bold;
+  color: $color-callout-general;
+}
+
+.callout__tool-icon {
+  position: absolute;
+  height: 27px;
+  width: 27px;
+  left: 0;
+  bottom: 0;
 }
 
 .callout--instructional {

--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -4,18 +4,26 @@
 //
 // Styleguide Call out
 
+$callout-border-top-height: 45px;
+
 %callout-icon {
+  @include body(22, 30);
   border-radius: 50%;
   display: inline-block;
+  vertical-align: middle;
   height: 30px;
   width: 30px;
   background: white;
   margin-right: $baseline-unit;
+  font-weight: 700;
+  text-align: center;
 }
 
 .callout {
+  position: relative;
   margin: $baseline-unit*2 0;
   border: 2px solid $color-callout-general;
+  border-top: $callout-border-top-height solid $color-callout-general;
   clear: right;
 
   h3 {
@@ -23,15 +31,22 @@
     color: white;
     background: $color-callout-general;
     margin: 0;
+    margin-top: -$callout-border-top-height;
     padding: $baseline-unit $baseline-unit $baseline-unit $baseline-unit*3;
 
     &:before {
       @extend %callout-icon;
       content: '?';
-      font-weight: 700;
-      text-align: center;
       color: $color-callout-general;
     }
+  }
+
+  p:first-child:before {
+    @extend %callout-icon;
+    content: '?';
+    color: $color-callout-general;
+    position: absolute;
+    top: -$callout-border-top-height + 7px;
   }
 
   p {
@@ -51,6 +66,7 @@
 
 .callout--tool {
   border: 2px solid $color-callout-tool;
+  border-top: $callout-border-top-height solid $color-callout-tool;
   h3 {
     background: $color-callout-tool;
     &:before {
@@ -58,6 +74,9 @@
       content: '';
       vertical-align: middle;
     }
+  }
+  p:first-child:before {
+    content: " ";
   }
 }
 

--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -4,22 +4,39 @@
 //
 // Styleguide Call out
 
+%callout-icon {
+  border-radius: 50%;
+  display: inline-block;
+  height: 30px;
+  width: 30px;
+  background: white;
+  margin-right: $baseline-unit;
+}
+
 .callout {
-  padding: $baseline-unit*3 0 0 0;
-  margin: $baseline-unit*4 0;
-  border-radius: 5px;
-  background-color: $color-callout-background;
+  margin: $baseline-unit*2 0;
+  border: 2px solid $color-callout-general;
   clear: right;
 
   h3 {
-    @extend %heading-extra-small;
-    margin: 0 $baseline-unit*3 $baseline-unit;
-    text-transform: capitalize;
+    @extend %heading-small;
+    color: white;
+    background: $color-callout-general;
+    margin: 0;
+    padding: $baseline-unit $baseline-unit $baseline-unit $baseline-unit*3;
+
+    &:before {
+      @extend %callout-icon;
+      content: '?';
+      font-weight: 700;
+      text-align: center;
+      color: $color-callout-general;
+    }
   }
 
   p {
     @extend %type-callout;
-    margin: 0 $baseline-unit*3 $baseline-unit*3 $baseline-unit*3;
+    margin: $baseline-unit*3;
   }
 
   .editorial & {

--- a/assets/components/dough_theme/callout/_settings.scss
+++ b/assets/components/dough_theme/callout/_settings.scss
@@ -1,5 +1,5 @@
 // Callout
-$color-callout-background: $color-green-pale;
+$color-callout-general: $color-turquoise;
 $color-callout-instructional-background: $color-grey-pale;
 
 // Panels

--- a/assets/components/dough_theme/callout/_settings.scss
+++ b/assets/components/dough_theme/callout/_settings.scss
@@ -1,5 +1,6 @@
 // Callout
 $color-callout-general: $color-turquoise;
+$color-callout-tool: $color-orange-medium;
 $color-callout-instructional-background: $color-grey-pale;
 
 // Panels

--- a/assets/lib/_variables.scss
+++ b/assets/lib/_variables.scss
@@ -72,7 +72,7 @@ $color-red-medium: #d11d32;
 $color-red-bright: #ea4c49;
 $color-red-dark: #af2745;
 
-$color-orange-medium: #f06431;
+$color-orange-medium: #f96e49;
 $color-orange-dark: #c95d2d;
 
 $color-yellow-light: #ead548;

--- a/assets/lib/_variables.scss
+++ b/assets/lib/_variables.scss
@@ -32,6 +32,8 @@ $color-green-three: #f7fbed;
 $color-teal-light: #109e89;
 $color-teal-dark: #0e7f6c;
 
+$color-turquoise: #24aFA8;
+
 $color-blue-pale: #ebf2f5;
 $color-blue-light: #e6f2f7;
 $color-blue-medium: #003d8e;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
## Overview
See [this PR](https://github.com/moneyadviceservice/cms/pull/363) for full explanation of the changes.

## Specifics
This PR specifically adds the CSS to Yeast that styles the new Callout module.

It is made slightly more complicated by the fact that some, but not all of the snippets will have a `<h3>` and some will not (this is markup that is in the CMS, so we don't have template control over it. 
- When there is an `<h3>` we need it to appear as the full-width coloured section at the top. 
- When there is _not_ an `<h3>` we fake this by giving the first `<p>` element a `:before` psuedo-element instead of styling the heading. Hence the `span.callout__icon + p` selector.


