### PR TITLE
Refactoring Callout CSS for specificity

### DIFF
--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -30,7 +30,7 @@ $callout-border-top-height: 42px;
   }
 }
 
-.callout--editorial {
+%callout--editorial {
   h3 {
     text-indent: $baseline-unit*6;
     color: white;
@@ -52,6 +52,7 @@ $callout-border-top-height: 42px;
 }
 
 .callout--tip {
+  @extend %callout--editorial;
   border: 2px solid $color-callout-general;
   h3 {
     background: $color-callout-general;
@@ -59,6 +60,7 @@ $callout-border-top-height: 42px;
 }
 
 .callout--tool {
+  @extend %callout--editorial;
   border: 2px solid $color-callout-tool;
   h3 {
     background: $color-callout-tool;

--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -9,16 +9,32 @@ $callout-border-top-height: 42px;
 .callout {
   position: relative;
   margin: $baseline-unit*2 0;
-  border: 2px solid $color-callout-general;
-  clear: right;
 
   h3 {
     @extend %heading-small;
+    padding: $baseline-unit;
+  }
+
+  p {
+    @extend %type-callout;
+    margin: $baseline-unit*2;
+  }
+
+  .editorial & {
+    clear: right;
+    @include respond-to($mq-l) {
+      @include column(3.5, 7);
+      float: right;
+      margin-bottom: $baseline-unit*2;
+    }
+  }
+}
+
+.callout--editorial {
+  h3 {
     text-indent: $baseline-unit*6;
     color: white;
-    background: $color-callout-general;
     margin: 0;
-    padding: $baseline-unit;
   }
 
   span.callout__icon + p {
@@ -33,18 +49,12 @@ $callout-border-top-height: 42px;
       background: $color-callout-general;
     }
   }
+}
 
-  p {
-    @extend %type-callout;
-    margin: $baseline-unit*2;
-  }
-
-  .editorial & {
-    @include respond-to($mq-l) {
-      @include column(3.5, 7);
-      float: right;
-      margin-bottom: $baseline-unit*2;
-    }
+.callout--tip {
+  border: 2px solid $color-callout-general;
+  h3 {
+    background: $color-callout-general;
   }
 }
 
@@ -82,5 +92,6 @@ $callout-border-top-height: 42px;
 }
 
 .callout--instructional {
+  border: none;
   background-color: $color-panel-background;
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
In PR #24 I restyled the Callout module. Unfortunately we have used the `.callout` class in some of our tools and we do not want the new styles to cascade down into these.

This PR:
- Keeps some base Callout styles in the `.callout` class that can apply everywhere
- Adds a new silent modifier class `%callout--editorial` for the basic structure of the new article page callouts
- Moves any color theming into the `.callout-tip` and `.callout--tool`modifier classes which extend `%callout--editorial`

For reference, these are callouts:

![image](https://cloud.githubusercontent.com/assets/14920201/20888188/b10c9e42-baf5-11e6-86c8-2751b821de18.png)

