### PR TITLE
Fixing SCSS @extend warning

### DIFF
--- a/assets/components/dough_theme/form/_form.scss
+++ b/assets/components/dough_theme/form/_form.scss
@@ -85,10 +85,6 @@
   @extend %form-input;
 }
 
-.form__input-container .form__input:focus ~ .form__input-outline {
-  @extend %form-input-focus-container
-}
-
 .form__input--small {
   max-width: 80px;
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
Removes an unused SCSS extend, that causes deprecation warnings in the current version of SASS-Rails, and errors in future versions.

This will have no effect on the CSS that is generated.