### PR TITLE
TP: 7773, Comment: Shows mobile menu button only at smaller width

### DIFF
--- a/assets/layout/common/_header.scss
+++ b/assets/layout/common/_header.scss
@@ -140,7 +140,17 @@ $header-height: $baseline-unit*9;
     right: 0;
 
     @include respond-to($mq-m) {
+      top: 3px;
+    }
+
+    @include respond-to($mq-l) {
       display: none;
+    }
+
+    @include respond-to($mq-m) {
+      .mobile-nav__link--menu {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
Need to submit this PR once more because on testing it removes the search box at some sizes. 

Now only shows the mobile menu when the global nav is not shown, the search box is unchanged. 

![image](https://cloud.githubusercontent.com/assets/6080548/22023273/69f3d72a-dcbd-11e6-9f03-38ad63482356.png)

![image](https://cloud.githubusercontent.com/assets/6080548/22023270/623893e0-dcbd-11e6-9a71-31fb164c5b14.png)

 