### PR TITLE
TP: 7773, Comment: Bump version of Yeast to 1.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
After making a change to Yeast earlier I should have bumped the version (newest changes are not displaying on frontend/uat). This PR makes the change to the version number.