### PR TITLE
[DEV APPROVED] TP: 7924, Comment: Updates header breakpoints for global nav

### DIFF
--- a/assets/layout/common/_header.scss
+++ b/assets/layout/common/_header.scss
@@ -23,14 +23,9 @@ $header-height: $baseline-unit*9;
     position: relative;
 
     @include respond-to($mq-m) {
-      @include column(10);
+      @include column(7);
       vertical-align: top;
       margin-top: 12px;
-      margin-bottom: $baseline-unit*2;
-    }
-
-    @include respond-to($mq-l) {
-      @include column(8);
       margin-bottom: $baseline-unit;
     }
 
@@ -44,10 +39,10 @@ $header-height: $baseline-unit*9;
   }
 
   .authentication {
-    @include column(1);
+    @include column(2);
     display: none;
 
-    @include respond-to($mq-l) {
+    @include respond-to($mq-m) {
       @include inline-block;
     }
 
@@ -111,7 +106,7 @@ $header-height: $baseline-unit*9;
     clear: both;
     padding: $baseline-unit*3 $baseline-unit;
 
-    @include respond-to($mq-l) {
+    @include respond-to($mq-m) {
       @include column(3);
       border: 0;
       background-color: transparent;
@@ -119,6 +114,7 @@ $header-height: $baseline-unit*9;
       margin-top: $baseline-unit*2;
       margin-bottom: $baseline-unit*2;
       padding: 0;
+      float: right;
 
       .search__input {
         border: 0;
@@ -185,7 +181,7 @@ $header-height: $baseline-unit*9;
       display: block;
     }
 
-    @include respond-to($mq-l) {
+    @include respond-to($mq-m) {
       display: block;
     }
   }
@@ -236,7 +232,7 @@ $header-height: $baseline-unit*9;
 .l-header__strapline {
   display: none;
 
-  @include respond-to($mq-m) {
+  @include respond-to($mq-l) {
     @include paragraph(14, 24);
     border-left: 1px solid rgb(255,255,255);
     color: $color-white;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
With the introduction of the Global Nav the behaviour of the search box needs to be modified so that it only functions as a dropdown version when the nav is not displayed. This necessitates some updating to the header layout as below. 

## < 720px
![image](https://cloud.githubusercontent.com/assets/6080548/22153750/86d89faa-df20-11e6-8d91-ae72107316a8.png)

## 720px - 959px
![image](https://cloud.githubusercontent.com/assets/6080548/22153831/d9346a40-df20-11e6-939c-145ea7fdfc95.png)

## 960px - 1199px
![image](https://cloud.githubusercontent.com/assets/6080548/22153910/27fc4e72-df21-11e6-87f6-edc528273f73.png)

## > 1200px
![image](https://cloud.githubusercontent.com/assets/6080548/22153923/3b458570-df21-11e6-9f8a-e61e821691fb.png)

Requires changes in Frontend PR1661: https://github.com/moneyadviceservice/frontend/pull/1661


