### PR TITLE
Bumping version to 1.5.1 to fix a tagging problem

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
We are having some trouble with tagging the release where the changes arent present in 1.5.0, so this PR creates a new yeast patch version which only bumps the version and contains no other changes.