### PR TITLE
8380 tooltip theme

### DIFF
--- a/assets/components/dough_theme/_all.scss
+++ b/assets/components/dough_theme/_all.scss
@@ -9,3 +9,4 @@
 @import "progress_indicator/all";
 @import "tab_selector/all";
 @import "tabular_tooltip/all";
+@import "popup_tip/all";

--- a/assets/components/dough_theme/popup_tip/_all.scss
+++ b/assets/components/dough_theme/popup_tip/_all.scss
@@ -1,0 +1,2 @@
+@import 'button';
+@import 'content';

--- a/assets/components/dough_theme/popup_tip/_button.scss
+++ b/assets/components/dough_theme/popup_tip/_button.scss
@@ -1,0 +1,9 @@
+.popup-tip__button {
+  font-style: italic;
+  font-weight: 700;
+  color: $color-green-secondary;
+}
+
+.popup-tip__close {
+  border-color: $color-grey-dark;
+}

--- a/assets/components/dough_theme/popup_tip/_content.scss
+++ b/assets/components/dough_theme/popup_tip/_content.scss
@@ -1,0 +1,5 @@
+.popup-tip__content {
+  .js & {
+    border-color: $color-blue-bright;
+  }
+}


### PR DESCRIPTION
## Adds popup tip theme

This PR adds the MAS theme to the popup tooltip component added to dough in the following PR:

https://github.com/moneyadviceservice/dough/pull/285

<img src="https://user-images.githubusercontent.com/13165846/28163862-b93718aa-67c4-11e7-9f14-53cd272e5c9a.png" width="400" />
