### PR TITLE
[DEV APPROVED]Improve contrast between colours in callout icon

### DIFF
--- a/assets/components/dough_theme/callout/_callout.scss
+++ b/assets/components/dough_theme/callout/_callout.scss
@@ -87,7 +87,7 @@ $callout-border-top-height: 42px;
   border-radius: 50%;
   text-align: center;
   font-weight: bold;
-  color: $color-callout-general;
+  color: $color-grey-primary;
 }
 
 .callout__tool-icon {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/entity/8495)

Part 1 of the Target Process story: Element has insufficient colour contrast of `2.7` (foreground colour: #24afa8, background colour: #ffffff, font size: 16.5pt, font weight: bold).

With this change contrast ratio goes up to `7.94:1`.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/689327/29175758-d5a50852-7de1-11e7-8a52-914f813d381b.png)
After:
![image](https://user-images.githubusercontent.com/689327/29175938-5c0ebcf8-7de2-11e7-82d6-2383461536a1.png)


Issue ID: DAC_TECH_Colour_01