### PR TITLE
[DEV APPROVED] - Bump version to 1.5.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
Versions `1.5.2` and `1.5.3` were tagged in git, but `bower.json` hadn't been updated. This PR updates it to what the current new tag is going to be.