### PR TITLE
[DEV APPROVED] TP: 7975, Comment: Removes breadcrumbs from display in mobile view

### DIFF
--- a/assets/layout/common/_context_bar.scss
+++ b/assets/layout/common/_context_bar.scss
@@ -1,9 +1,8 @@
 .l-context-bar {
-  @include respond-to($mq-xs, $mq-s-max) {
-    @include visually-hidden;
-  }
+  display: none;
 
   @include respond-to($mq-m) {
+    display: block;
     background-color: $breadcrumbs-background-color;
     padding-top: $baseline-unit*3;
     padding-bottom: $baseline-unit*3;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
**Target Process ticket**
[TP7975](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/7975)

**Summary**
This is a site-wide issue. We have visually hidden the breadcrumbs at mobile view but these remain accessible to screen-readers, which causes confusion to users of that assistive technology. 

This PR removes the breadcrumbs entirely in the mobile view so the same experience exists for both users and non-users of screen readers. 

**Examples**
The black highlight shows the area that VoiceOver considers active when tabbing through the page, which is the visually hidden breadcrumb on the production site: 

![image](https://user-images.githubusercontent.com/6080548/32272621-c8a1531c-bef6-11e7-9fb9-e63cb3c2383a.png)

Tabbing now moves the user to the next link: 

![image](https://user-images.githubusercontent.com/6080548/32272643-e2e31e36-bef6-11e7-8529-f5eea45b2d84.png)

**QA / Testing**
Needs to be tested with VoiceOver

Requires change in [PR1835](https://github.com/moneyadviceservice/frontend/pull/1835) on Frontend. 