### PR TITLE
[DEV APPROVED]8647 tooltip icon

### DIFF
--- a/assets/components/dough_theme/popup_tip/_button.scss
+++ b/assets/components/dough_theme/popup_tip/_button.scss
@@ -1,7 +1,14 @@
 .popup-tip__button {
+  font-family: Times, "Times New Roman", Georgia, serif;
+  font-size: 1rem;
   font-style: italic;
-  font-weight: 700;
-  color: $color-green-secondary;
+  font-weight: bold;
+  color: $color-white;
+  display: inline-block;
+  width: 25px;
+  height: 25px;
+  background-color: $color-green-secondary;
+  border-radius: 50%;
 }
 
 .popup-tip__close {

--- a/assets/components/dough_theme/popup_tip/_content.scss
+++ b/assets/components/dough_theme/popup_tip/_content.scss
@@ -3,3 +3,19 @@
     border-color: $color-blue-bright;
   }
 }
+
+.popup-tip__content {
+  .js & {
+    @include respond-to($mq-m) {
+      padding: $baseline-unit;
+    }
+  }
+}
+
+.popup-tip__title--no-js {
+  display: inline;
+
+  .js & {
+    display: none;
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
[TP8647](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/8479&appConfig=eyJhY2lkIjoiREREN0YzQTYyNjg0NEFCOEQxQkVFM0YwNkVDMjhFRkEifQ==&searchPopup=userstory/8647)

This PR provides the MAS-specific styles for the [Dough Tooltip Helpers](https://github.com/moneyadviceservice/dough/pull/291) in the areas of the site where they are used. 