### PR TITLE
[DEV APPROVED] Updates styles to render smallprint bold

### DIFF
--- a/assets/layout/common/_contact_panel.scss
+++ b/assets/layout/common/_contact_panel.scss
@@ -13,6 +13,15 @@
   flex-direction: column;
   align-items: center;
 
+  .smallprint {
+    display: none;
+    font-weight: bold;
+
+    .theme-cy & {
+      display: block;
+    }
+  }
+
   @include respond-to($mq-s) {
     padding: $baseline-unit*4 0;
   }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
[TP10734](https://maps.tpondemand.com/entity/10734-remove-whatsapp-contact-option-from-welsh)

This work updates the small-print text that is found on two fo the panels in the footer when viewing the site in Welsh.  The requirement is to move this text so that it is above the buttons and to make it bold. There is a further requirement to update the content of that text but that is out of the scope fo this work as it is CMS controlled. 

The work is in 2 PRs: 
- This one, that makes the style change to embolden the text and remove from English language rendering of footer. 
- [PR2182](https://github.com/moneyadviceservice/frontend/pull/2182) in Frontend that makes the markup change to alter the position of the elements

Current
![image](https://user-images.githubusercontent.com/6080548/72916124-55322000-3d39-11ea-80a5-6472d4c4d4b6.png)

Updated
![image](https://user-images.githubusercontent.com/6080548/72916151-69761d00-3d39-11ea-9cbc-6a5a0baee3e3.png)
