### PR TITLE
11363 sticky banner coronavirus info

### DIFF
--- a/assets/layout/common/_covid_banner.scss
+++ b/assets/layout/common/_covid_banner.scss
@@ -1,0 +1,90 @@
+.covid_banner {
+	position: fixed;
+	width: 100%;
+	bottom: $baseline-unit*2;
+	padding-right: calc(76px + #{$default-gutter * 4}); 
+	padding-left: $default-gutter; 
+	z-index: 5; 
+	transition: bottom .4s;
+
+	@include respond-to($mq-s) {
+		padding-right: calc(76px + #{$default-gutter * 2}); 		
+	}
+
+	@include respond-to($mq-l) {
+		padding-left: 0; 
+		padding-right: 0; 
+	}
+
+	&.covid_banner--raised {
+		bottom: 55px;
+	}
+}
+
+.covid_banner--hidden {
+	display: none;
+}
+
+.covid_banner__content {
+	width: 100%; 
+	padding: 0 $default-gutter * 2;
+	border-radius: .15em;
+	background: $color-yellow-light;
+
+	@include respond-to($mq-m) {
+		padding-left: $default-gutter;
+		padding-right: $default-gutter;
+	}
+
+	@include respond-to($mq-l) {
+		@include column(12); 
+	}
+}
+
+.covid_banner__inner {
+	display: flex; 
+	flex-direction: column;
+	justify-content: center;
+	height: 70px; 
+	position: relative; 
+}
+
+.covid_banner__close {
+	display: none; 
+	position: absolute; 
+	top: $baseline-unit * 2;
+	right: 0; 
+
+	.js & {
+		display: block; 
+	}
+}
+
+.svg-icon--mobile-close-box {
+	width: 12.291px; 
+	height: 11.878px; 
+}
+
+.covid_banner__head, 
+.covid_banner__body {
+	margin: 0;
+	line-height: 1.2; 
+}
+
+.covid_banner__head {
+	font-size: 1rem; 
+	font-weight: bold; 
+	padding-right: calc(12.291px + #{$default-gutter * 2}); 
+
+	@include respond-to($mq-s) {
+		font-size: 1.125rem; 
+	}
+}
+
+.covid_banner__body {
+	font-size: 0.75rem;  
+
+	a {
+		text-decoration: underline;
+	}
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
[TP11363](https://maps.tpondemand.com/entity/11363-sticky-banner-on-mas-website-for)

This work adds a banner to direct users to our articles on Coronavirus. 

There are three PRs that make up the implementation of this component: 
- [PR2201](https://github.com/moneyadviceservice/frontend/pull/2201) in frontend that provides the content and markup for the banner, as well as the Rails functionality to render the component only when this is not recorded in a Cookie as having been previously dismissed, and the reference to the associated Dough component. 
- PR61 in yeast (this PR) that provides the styles for the component, and which will be shared with other repos, such as RAD. 
- [PR338](https://github.com/moneyadviceservice/dough/pull/338) in dough that provides the JavaScript component and associated Unit Tests for the behaviour of the banner. This PR also updates the ChatPopup component, necessary to handle the dynamic positioning of the banner on article pages. 

**Banner on the home page**

![image](https://user-images.githubusercontent.com/6080548/77449907-7a4f1780-6dea-11ea-9885-7ffabf3969fc.png)

**Banner on an article page**

![image](https://user-images.githubusercontent.com/6080548/77450028-9e125d80-6dea-11ea-9eca-52217aa2a05e.png)
