### PR TITLE
[DEV APPROVED] 11381 js missing

### DIFF
--- a/assets/layout/common/_covid_banner.scss
+++ b/assets/layout/common/_covid_banner.scss
@@ -1,4 +1,5 @@
 .covid_banner {
+	display: none; 
 	position: fixed;
 	width: 100%;
 	bottom: $baseline-unit*2;
@@ -19,10 +20,14 @@
 	&.covid_banner--raised {
 		bottom: 55px;
 	}
-}
 
-.covid_banner--hidden {
-	display: none;
+	&[data-dough-covid-banner-initialised="yes"] {
+		display: block; 
+
+		&.covid_banner--hidden {
+			display: none;
+		}
+	}
 }
 
 .covid_banner__content {

--- a/assets/layout/common/_header.scss
+++ b/assets/layout/common/_header.scss
@@ -189,7 +189,7 @@ $maps_bannerHeight_l: 110px;
     }
   }
 
-  .js & .l-search {
+  body[data-dough-component-loader-all-loaded="yes"] & .l-search {
     display: none;
 
     &.is-on {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "yeast",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "homepage": "https://github.com/moneyadviceservice/yeast",
   "authors": [
     "Ben Barnett <ben.barnett@moneyadviceservice.org.uk>",


### PR DESCRIPTION
[TP11381](https://maps.tpondemand.com/entity/11381-dough-not-initialised-on-some-mas)

There are 2 PRs in this piece of work: 
- [PR2212](https://github.com/moneyadviceservice/frontend/pull/2212) on Frontend 
- PR62 on Yeast (this one)

It makes some small changes to our CSS to deal with issues that have become evident where third party users are loading our "empty template" to create content on the MAS estate.

There are a number of problems on the two tool pages this card caused by the usual MAS JavaScript being blocked and a number of page components break, specifically: 
- The Search Box has no means of clearing the input.
- The Navigation on desktop functions with CSS rather than JavaScript. The JavaScript provides a slightly enhanced experience as well as a number of accessibility features. 
- On mobile the navigation is not rendered at all. 
- On mobile the search box is permanently displayed and is not collapsable. 
- On mobile the floating web chat button is not collapsable or expandable. 
- The Coronavirus banner is not dismissible.

It was decided, in the short term at least, not to fix these issues but to ameliorate the worst effects of them with the CSS additions within these PRs. This is largely based on basing styles on the "dough-initialised" tag rather than the "js" hook in the `<body>` tag.

N.B. This is not easily testable locally since the issue occurs in a third party setting.
